### PR TITLE
Adds lib dependency on libintl (for windows).

### DIFF
--- a/hgettext.cabal
+++ b/hgettext.cabal
@@ -21,6 +21,8 @@ Library
         Build-Depends:          base>=3.0.3.0 && <5, process,
                                 directory, filepath,
                                 containers, Cabal>=1.10, setlocale
+        if os(windows)
+           extra-libraries:     libintl
 
 Executable hgettext
         Main-Is:                hgettext.hs


### PR DESCRIPTION
Adds dependency on libintl so that the definitions are found when linking the library (in windows).
Closes issue #2 on vasylp/hgettext.
