### PR TITLE
Include correct source lines in messages.pot

### DIFF
--- a/src/hgettext.hs
+++ b/src/hgettext.hs
@@ -1,3 +1,4 @@
+module Main where
 
 import qualified Language.Haskell.Exts.Annotated as H
 
@@ -50,26 +51,29 @@ parseArgs args =
     where header = "Usage: hgettext [OPTION] [INPUTFILE] ..."
 
 
-toTranslate :: String -> H.ParseResult (H.Module H.SrcSpanInfo) -> [(Int, String)]
+toTranslate :: String
+            -> H.ParseResult (H.Module H.SrcSpanInfo)
+            -> [(Int, String)]
 toTranslate f (H.ParseOk z) =
-    nubBy ((==) `on` snd)
-        [ (H.srcSpanStartLine (H.srcInfoSpan l), s)
+    nub [ (H.srcSpanStartLine (H.srcInfoSpan l), s)
         | H.App _ (H.Var _ (H.UnQual _ (H.Ident _ x)))
                   (H.Lit _ (H.String l s _)) <- universeBi z
         , x == f
         ]
 toTranslate _ _ = []
 
--- Create list of messages from a single file
-formatMessages :: String -> [(Int, String)] -> String
-formatMessages src l = concat $ map potEntry l
-    where potEntry (l, s) = unlines [
-                             "#: " ++ src ++ ":" ++ (show l),
+formatMessage :: String
+              -> [(String, Int)]
+              -> String
+formatMessage s locs = unlines $
+                            map (uncurry formatLoc) locs ++
+                            [
                              "msgid " ++ (show s),
                              "msgstr \"\"",
                              ""
                             ]
-
+  where
+    formatLoc src l = "#: " ++ src ++ ":" ++ (show l)
 
 writePOTFile :: [String] -> String
 writePOTFile l = concat $ [potHeader] ++ l
@@ -89,15 +93,27 @@ writePOTFile l = concat $ [potHeader] ++ l
                                "\"Content-Transfer-Encoding: 8bit\\n\"",
                                ""]
 
+parseFile :: String
+          -> IO (H.ParseResult (H.Module H.SrcSpanInfo))
+parseFile "-" = fmap H.parseFileContents getContents
+parseFile f   = H.parseFile f
+
 process :: Options -> [String] -> IO ()
 process Options{printVersion = True} _ = 
     putStrLn $ "hgettext, version " ++ (showVersion version)
 
 process opts fl = do
-  t <- mapM read' fl
-  writeFile (outputFile opts) $ writePOTFile $ map (\(n,c) -> formatMessages n $ toTranslate (keyword opts) c) t
-    where read' "-" = getContents >>= \c -> return ("-", H.parseFileContents c)
-          read' f = H.parseFile f >>= \m -> return (f, m)
+  parseResults <- mapM parseFile fl
+
+  let messages = [ (str, (filename, lineNumber))
+                 | (filename, ast) <- zip fl parseResults
+                 , (lineNumber, str) <- toTranslate (keyword opts) ast
+                 ]
+
+      formatted = [ formatMessage s (map snd xs)
+                  | xs@((s, _):_) <- groupBy ((==) `on` fst) $ sort messages
+                  ]
+  writeFile (outputFile opts) $ writePOTFile formatted
 
 main = 
     getArgs >>= parseArgs >>= uncurry process

--- a/src/hgettext.hs
+++ b/src/hgettext.hs
@@ -10,6 +10,7 @@ import Distribution.Simple.PreProcess.Unlit
 
 import Data.List
 import Data.Char
+import Data.Function (on)
 import System.FilePath
 
 import Paths_hgettext (version)
@@ -51,7 +52,8 @@ parseArgs args =
 
 toTranslate :: String -> H.ParseResult (H.Module H.SrcSpanInfo) -> [(Int, String)]
 toTranslate f (H.ParseOk z) =
-    nub [ (H.srcSpanStartLine (H.srcInfoSpan l), s)
+    nubBy ((==) `on` snd)
+        [ (H.srcSpanStartLine (H.srcInfoSpan l), s)
         | H.App _ (H.Var _ (H.UnQual _ (H.Ident _ x)))
                   (H.Lit _ (H.String l s _)) <- universeBi z
         , x == f

--- a/src/hgettext.hs
+++ b/src/hgettext.hs
@@ -1,5 +1,5 @@
 
-import qualified Language.Haskell.Exts as H 
+import qualified Language.Haskell.Exts.Annotated as H
 
 import System.Environment
 import System.Console.GetOpt
@@ -49,8 +49,13 @@ parseArgs args =
     where header = "Usage: hgettext [OPTION] [INPUTFILE] ..."
 
 
-toTranslate :: String -> H.ParseResult H.Module -> [(Int, String)]
-toTranslate f (H.ParseOk z) = nub [ (0, s) | H.App (H.Var (H.UnQual (H.Ident x))) (H.Lit (H.String s)) <- universeBi z, x == f]
+toTranslate :: String -> H.ParseResult (H.Module H.SrcSpanInfo) -> [(Int, String)]
+toTranslate f (H.ParseOk z) =
+    nub [ (H.srcSpanStartLine (H.srcInfoSpan l), s)
+        | H.App _ (H.Var _ (H.UnQual _ (H.Ident _ x)))
+                  (H.Lit _ (H.String l s _)) <- universeBi z
+        , x == f
+        ]
 toTranslate _ _ = []
 
 -- Create list of messages from a single file


### PR DESCRIPTION
Currently, the pot file generated by hgettext claims that each string is at line 0. Here's a simple patch to fix that.

Language.Haskell.Exts.Annotated annotates each expression with its source location. So, we take the starting line of the string. All the _s added to the binding are for the other source locations, which we ignore.
