### PR TITLE
update to support haskell-src-exts-1.18

### DIFF
--- a/hgettext.cabal
+++ b/hgettext.cabal
@@ -26,6 +26,6 @@ Executable hgettext
         Main-Is:                hgettext.hs
         Extensions:             TemplateHaskell
         Hs-Source-Dirs:         src        
-        Build-Depends:          base>=3.0.3.0 && <5, uniplate, haskell-src-exts
+        Build-Depends:          base>=3.0.3.0 && <5, uniplate, haskell-src-exts >= 1.18
         Other-Modules:          Paths_hgettext
 

--- a/src/hgettext.hs
+++ b/src/hgettext.hs
@@ -49,8 +49,15 @@ parseArgs args =
     where header = "Usage: hgettext [OPTION] [INPUTFILE] ..."
 
 
-toTranslate :: String -> H.ParseResult H.Module -> [(Int, String)]
-toTranslate f (H.ParseOk z) = nub [ (0, s) | H.App (H.Var (H.UnQual (H.Ident x))) (H.Lit (H.String s)) <- universeBi z, x == f]
+toTranslate :: String -> H.ParseResult (H.Module H.SrcSpanInfo) -> [(Int, String)]
+toTranslate f (H.ParseOk z) = nub [ (0, s)
+                                  | H.App _
+                                        (H.Var _
+                                            (H.UnQual _
+                                                (H.Ident  _ x)))
+                                        (H.Lit _
+                                            (H.String _ s _slit)) <- universeBi z :: [H.Exp H.SrcSpanInfo]
+                                  , x == f]
 toTranslate _ _ = []
 
 -- Create list of messages from a single file


### PR DESCRIPTION
One of major haskell-src-exts-1.18 changes
is to parameterise AST with source location
and add that field to every ast node.

Signed-off-by: Sergei Trofimovich siarheit@google.com
