### PR TITLE
Fix Unicode support in hgettext utility

### DIFF
--- a/src-exe/hgettext.hs
+++ b/src-exe/hgettext.hs
@@ -11,6 +11,7 @@ import qualified Language.Haskell.Exts       as H
 import           System.Console.GetOpt
 import           System.Environment
 import           System.Exit
+import           System.IO                   (IOMode(WriteMode), hPutStr, hSetEncoding, utf8, withFile)
 
 import           Paths_hgettext              (version)
 
@@ -94,6 +95,12 @@ writePOTFile l = concat $ [potHeader] ++ l
                                "\"Content-Transfer-Encoding: 8bit\\n\"",
                                ""]
 
+writeFileUtf8 :: FilePath -> String -> IO ()
+writeFileUtf8 fp content =
+  withFile fp WriteMode $ \h -> do
+    hSetEncoding h utf8
+    hPutStr h content
+
 process :: Options -> [FilePath] -> IO ()
 process Options{printVersion = True} _ =
     putStrLn $ "hgettext, version " ++ (showVersion version)
@@ -104,7 +111,7 @@ process opts fl = do
 
     let entries = Map.fromListWith Set.union [ (s,Set.singleton (fn,loc)) | d <- dat, (s,(fn,loc)) <- d ]
 
-    writeFile (outputFile opts) $ do
+    writeFileUtf8 (outputFile opts) $ do
       writePOTFile [ formatMessage s (Set.toList locs) | (s,locs) <- Map.toList entries ]
   where
     readSource "-" = do

--- a/src-exe/hgettext.hs
+++ b/src-exe/hgettext.hs
@@ -57,10 +57,18 @@ toTranslate f z = [ (H.srcSpanStartLine (H.srcInfoSpan loc), s)
                     <- universeBi z :: [H.Exp H.SrcSpanInfo]
                   , x == f]
 
+showStringLit :: String -> String
+showStringLit s0 = '"' : concatMap showChar s0 ++ "\""
+    where
+      showChar '"' = "\\\""
+      showChar '\\' = "\\\\"
+      showChar '\n' = "\\n"
+      showChar c = return c
+
 formatMessage :: String -> [(FilePath, Int)] -> String
 formatMessage s locs = unlines $
                        map (uncurry formatLoc) locs ++
-                       [ "msgid " ++ (show s)
+                       [ "msgid " ++ (showStringLit s)
                        , "msgstr \"\""
                        , ""
                        ]


### PR DESCRIPTION
Previously, the `hgettext` utility used `show` function to escape strings in the generated PO file. This lead to Unicode characters being incorrectly escaped, for example, `…` became `\8230` instead of `\x2026`.

This tripped up `xgettext` command, especially when used with `--join-existing` option.

According to [gettext documentation](https://www.gnu.org/software/gettext/manual/html_node/PO-Files.html), the strings use C syntax so we are using functions for escaping C strings.
