### PR TITLE
Bump simple version bounds

### DIFF
--- a/hgettext.cabal
+++ b/hgettext.cabal
@@ -31,8 +31,8 @@ library
   other-modules:     Internal
 
   hs-source-dirs:    src
-  build-depends:     base             >=4.5    && <4.11
-                   , Cabal            >=1.14   && <1.25 || == 2.0.*
+  build-depends:     base             >=4.5    && <4.13
+                   , Cabal            >=1.14   && <1.25 || == 2.0.* || == 2.2.*
                    , containers       >=0.4.2  && <0.6
                    , directory        >=1.1    && <1.4
                    , filepath         >=1.3    && <1.5
@@ -61,7 +61,7 @@ executable hgettext
                    , filepath
 
   build-depends:     deepseq          >=1.1    && <1.5
-                   , haskell-src-exts >=1.18   && <1.21
+                   , haskell-src-exts >=1.18   && <1.24
                    , uniplate         >=1.6.12 && <1.7
 
   ghc-options:       -Wall


### PR DESCRIPTION
This also includes the revision to the `Cabal` bounds introduced by @hvr on Hackage; if you prefer to keep version bumps there rather than on Github, feel free to close this PR after updating the revision there.  Critically, the old `haskell-src-exts` version is preventing the Gentoo Haskell repository from updating the packaging for that dependency.   I've successfully built all the new bounds with GHC 8.6.5, but as there is no test suite, there's a chance some behaviour might have changed somewhere.