### PR TITLE
Cabal bump for GHC-9.10.3 to 9.14.1

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -52,11 +52,6 @@ jobs:
             compilerVersion: 9.10.3
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.10.1
-            compilerKind: ghc
-            compilerVersion: 9.10.1
-            setup-method: ghcup
-            allow-failure: false
           - compiler: ghc-9.8.4
             compilerKind: ghc
             compilerVersion: 9.8.4

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -6,11 +6,11 @@
 #
 #   haskell-ci regenerate
 #
-# For more information, see https://github.com/andreasabel/haskell-ci
+# For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.19.20241219
+# version: 0.19.20260209
 #
-# REGENDATA ("0.19.20241219",["github","hgettext.cabal"])
+# REGENDATA ("0.19.20260209",["github","hgettext.cabal"])
 #
 name: Haskell-CI
 on:
@@ -20,10 +20,15 @@ on:
   pull_request:
     branches:
       - master
+  merge_group:
+    branches:
+      - master
+  workflow_dispatch:
+    {}
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes:
       60
     container:
@@ -32,6 +37,21 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.14.1
+            compilerKind: ghc
+            compilerVersion: 9.14.1
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.12.2
+            compilerKind: ghc
+            compilerVersion: 9.12.2
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.10.3
+            compilerKind: ghc
+            compilerVersion: 9.10.3
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-9.10.1
             compilerKind: ghc
             compilerVersion: 9.10.1
@@ -101,13 +121,12 @@ jobs:
       - name: Install GHCup
         run: |
           mkdir -p "$HOME/.ghcup/bin"
-          curl -sL https://downloads.haskell.org/ghcup/0.1.30.0/x86_64-linux-ghcup-0.1.30.0 > "$HOME/.ghcup/bin/ghcup"
+          curl -sL https://downloads.haskell.org/ghcup/0.1.50.1/x86_64-linux-ghcup-0.1.50.1 > "$HOME/.ghcup/bin/ghcup"
           chmod a+x "$HOME/.ghcup/bin/ghcup"
-      - name: Install cabal-install (prerelease)
+      - name: Install cabal-install
         run: |
-          "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.8.yaml;
-          "$HOME/.ghcup/bin/ghcup" install cabal 3.15.0.0.2024.10.3 || (cat "$HOME"/.ghcup/logs/*.* && false)
-          echo "CABAL=$HOME/.ghcup/bin/cabal-3.15.0.0.2024.10.3 -vnormal+nowrap" >> "$GITHUB_ENV"
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.16.0.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.16.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
       - name: Install GHC (GHCup)
         if: matrix.setup-method == 'ghcup'
         run: |
@@ -183,7 +202,7 @@ jobs:
           chmod a+x $HOME/.cabal/bin/cabal-plan
           cabal-plan --version
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: source
       - name: initial cabal.project for sdist
@@ -208,7 +227,11 @@ jobs:
           touch cabal.project.local
           echo "packages: ${PKGDIR_hgettext}" >> cabal.project
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package hgettext" >> cabal.project ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods -Werror=missing-fields" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "package hgettext" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "    ghc-options: -Werror=unused-packages" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "package hgettext" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "    ghc-options: -Werror=incomplete-patterns -Werror=incomplete-uni-patterns" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           EOF
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(hgettext)$/; }' >> cabal.project.local

--- a/hgettext.cabal
+++ b/hgettext.cabal
@@ -56,7 +56,6 @@ library
   hs-source-dirs:    src
   build-depends:     base             >=4.5    && <4.23
                    , Cabal            >=1.14   && <1.25 || >= 2.0 && < 2.5 || >=3.0 && <3.17
-                   , containers       >=0.4.2  && <0.9
                    , directory        >=1.1    && <1.4
                    , filepath         >=1.3    && <1.6
                    , process          >=1.1    && <1.7
@@ -77,13 +76,10 @@ executable hgettext
   hs-source-dirs:    src-exe
 
   -- constraints inherited from lib:hgettext
-  build-depends:     hgettext
-                   , base
-                   , Cabal
-                   , containers
-                   , filepath
+  build-depends:     base
 
-  build-depends:     deepseq          >=1.1      && <1.6
+  build-depends:     containers       >=0.4.2    && <0.9
+                   , deepseq          >=1.1      && <1.6
                    , cpphs            >=1.20.9.1 && <1.20.11
                    , haskell-src-exts >=1.18     && <1.24
                    , uniplate         >=1.6.12   && <1.7

--- a/hgettext.cabal
+++ b/hgettext.cabal
@@ -19,6 +19,9 @@ description:         This package provides bindings to the @gettext@ internation
                      A user-contributed tutorial can be found in the [Haskell Wiki](https://wiki.haskell.org/Internationalization_of_Haskell_programs_using_gettext).
 
 tested-with:
+  GHC == 9.14.1
+  GHC == 9.12.2
+  GHC == 9.10.3
   GHC == 9.10.1
   GHC == 9.8.4
   GHC == 9.6.6
@@ -51,9 +54,9 @@ library
   other-modules:     Internal
 
   hs-source-dirs:    src
-  build-depends:     base             >=4.5    && <4.22
-                   , Cabal            >=1.14   && <1.25 || >= 2.0 && < 2.5 || >=3.0 && <3.15
-                   , containers       >=0.4.2  && <0.8
+  build-depends:     base             >=4.5    && <4.23
+                   , Cabal            >=1.14   && <1.25 || >= 2.0 && < 2.5 || >=3.0 && <3.17
+                   , containers       >=0.4.2  && <0.9
                    , directory        >=1.1    && <1.4
                    , filepath         >=1.3    && <1.6
                    , process          >=1.1    && <1.7
@@ -80,8 +83,8 @@ executable hgettext
                    , containers
                    , filepath
 
-  build-depends:     deepseq          >=1.1      && <1.6
-                   , cpphs            >=1.20.9.1 && <1.20.10
+  build-depends:     deepseq          >=1.1      && <1.7
+                   , cpphs            >=1.20.9.1 && <1.20.11
                    , haskell-src-exts >=1.18     && <1.24
                    , uniplate         >=1.6.12   && <1.7
                    , split            >=0.2.3.4  && <0.3

--- a/hgettext.cabal
+++ b/hgettext.cabal
@@ -22,7 +22,6 @@ tested-with:
   GHC == 9.14.1
   GHC == 9.12.2
   GHC == 9.10.3
-  GHC == 9.10.1
   GHC == 9.8.4
   GHC == 9.6.6
   GHC == 9.4.8

--- a/hgettext.cabal
+++ b/hgettext.cabal
@@ -83,7 +83,7 @@ executable hgettext
                    , containers
                    , filepath
 
-  build-depends:     deepseq          >=1.1      && <1.7
+  build-depends:     deepseq          >=1.1      && <1.6
                    , cpphs            >=1.20.9.1 && <1.20.11
                    , haskell-src-exts >=1.18     && <1.24
                    , uniplate         >=1.6.12   && <1.7

--- a/hgettext.cabal
+++ b/hgettext.cabal
@@ -75,10 +75,8 @@ executable hgettext
 
   hs-source-dirs:    src-exe
 
-  -- constraints inherited from lib:hgettext
-  build-depends:     base
-
-  build-depends:     containers       >=0.4.2    && <0.9
+  build-depends:     base             >=4.5      && <4.23
+                   , containers       >=0.4.2    && <0.9
                    , deepseq          >=1.1      && <1.6
                    , cpphs            >=1.20.9.1 && <1.20.11
                    , haskell-src-exts >=1.18     && <1.24


### PR DESCRIPTION
I've revised `hgettext.cabal` file, updating versions of dependencies and adding tests for GHC-9.10.3 to 9.14.1. I've also regenerated the workflow file appropriately using [`haskell-ci`](https://github.com/haskell-CI/haskell-ci) tool (directly cloned from main branch).

What is interesting is that some dependencies were not even used (as reported by the compiler with `-Wunused-packages -Werror=unused-packages` flags when workflow jobs failed) so I've removed them. The only thing left is merging #28 for Cabal 3.14 to become supported.

@andreasabel I've done everything [you requested](https://github.com/haskell-hvr/hgettext/pull/28#issuecomment-3794747667). Can you please review the changes of this pull request? Thanks.